### PR TITLE
remove use of undefined constant FIXME

### DIFF
--- a/admin/list.php
+++ b/admin/list.php
@@ -25,7 +25,6 @@ class admin_plugin_unusedmedias_list extends DokuWiki_Admin_Plugin {
 	private $error 			= "";
 	private $ok				= "";
 	
-    public function getMenuSort() { return FIXME; }
     public function forAdminOnly() { return true; }
    
     public function handle() {


### PR DESCRIPTION
Remove the getMenuSort() method and use the one provided
by the parent class (DokuWiki_Admin_Plugin), which returns 1000.
This is used to determine the position in the admin menu on
admin window and is not really relevant.

fixes #3 